### PR TITLE
Add npm start script, rename token var, new Docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,1 @@
-FROM library/node:slim
-
-COPY . /app
-
-RUN cd /app \
-  && npm install --production
-
-WORKDIR /app
+FROM node:6.2-onbuild

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "pretest": "jscs ./lib/",
-    "test": "mocha tests/*.js"
+    "test": "mocha tests/*.js",
+    "start": "node slack_bot.js"
   },
   "repository": {
     "type": "git",

--- a/slack_bot.js
+++ b/slack_bot.js
@@ -64,8 +64,8 @@ This bot demonstrates many of the core features of Botkit:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
 
-if (!process.env.token) {
-    console.log('Error: Specify token in environment');
+if (!process.env.SLACK_TOKEN) {
+    console.log('Error: Specify SLACK_TOKEN in environment');
     process.exit(1);
 }
 
@@ -73,11 +73,11 @@ var Botkit = require('./lib/Botkit.js');
 var os = require('os');
 
 var controller = Botkit.slackbot({
-    debug: true
+    debug: false
 });
 
 var bot = controller.spawn({
-    SLACK_TOKEN: process.env.token
+    token: process.env.SLACK_TOKEN
 }).startRTM();
 
 var HarQuotes = [


### PR DESCRIPTION
Alex,

I fixed this up so that it should run properly in Docker now. Also, the variable for the single team slack token gets passed as `SLACK_TOKEN` so I renamed the variable as well. The key piece was adding a `start` script in the `package.json`.

Running locally now should look something like this:
`SLACK_TOKEN=xoxb-xxxxxxx npm start`

If you want to test that it runs in Docker properly:

```
docker build -t mybot .
docker run -it -e SLACK_TOKEN=xoxb-xxxxxxx mybot
```

Just make sure you replace `xoxb-xxxxxxx` with your actual bot token 😉 
